### PR TITLE
Roland/deploy docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,14 +16,9 @@ RUN npm install --ignore-scripts
 # Install open api for combined both back and front end
 RUN npm install @openapitools/openapi-generator-cli -g
 
-# Install open api for combined both back and front end
-# RUN npm install @openapitools/openapi-generator-cli -g
-
 # Copy in the necessary files for tsoa
 COPY biogrid/apps apps
 COPY biogrid/tsconfig.json .
-
-# ENV PORT=8080
 
 COPY biogrid/babel.config.json biogrid/nx.json biogrid/workspace.json ./
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,30 +13,42 @@ COPY biogrid/package*.json ./
 # Install all required packages for build
 RUN npm install --ignore-scripts
 
+# Install open api for combined both back and front end
+RUN npm install @openapitools/openapi-generator-cli -g
+
+# Install open api for combined both back and front end
+# RUN npm install @openapitools/openapi-generator-cli -g
+
 # Copy in the necessary files for tsoa
 COPY biogrid/apps apps
 COPY biogrid/tsconfig.json .
 
-# Build tsoa 
-RUN npm run build:tsoa
+# ENV PORT=8080
 
-COPY biogrid/babel.config.json .
-COPY biogrid/nx.json .
-COPY biogrid/workspace.json .
+COPY biogrid/babel.config.json biogrid/nx.json biogrid/workspace.json ./
 
+# copy all the other dependent files
 COPY biogrid/libs libs
 COPY biogrid/tools tools
 
+# Build tsoa 
+RUN npm run build:tsoa
+
+# Make output directories for api and frontend
+RUN mkdir -p /usr/src/repo/dist/apps/biogrid-mvp
+RUN mkdir -p /usr/src/repo/dist/apps/api
+RUN mkdir -p /usr/src/repo/apps/biogrid-mvp/src/app/dist
+
 # Build production instances of the mvp
 # Nx seg faults after building, so an or statement negates the issue
-RUN nx build biogrid-mvp --prod || echo 'continuing'
+RUN npm run build-api-client
 RUN nx build api --prod || echo 'continuing'
+RUN nx build biogrid-mvp --prod || echo 'continuing'
 
 # Remove dev deps
-RUN npm prune --production
+# TODO: Pruning removes the node_modules and everything. This is going to be fixed
+# RUN npm prune --production
 
-RUN chmod 777 /usr/local/bin/docker-entrypoint.sh \
-  && ln -s /usr/local/bin/docker-entrypoint.sh 
 EXPOSE 8080
 
 CMD ["node", "dist/apps/api/main.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
-FROM node:13
+FROM timbru31/java-node:11
+
+# Make a working directory
+WORKDIR /usr/src/repo
 
 # Install the necessary CLI packages
 RUN npm install -g @nrwl/cli
 
-WORKDIR /usr/src/repo
-
+# Install app dependencies
+# COPY both package.json AND package-lock.json
 COPY biogrid/package*.json ./
 
 # Install all required packages for build

--- a/biogrid/.dockerignore
+++ b/biogrid/.dockerignore
@@ -3,3 +3,12 @@ logs
 dist
 .vscode
 tmp
+README.md
+jest.config.js
+.editorconfig
+.eslintrc
+.eslintrc.json
+.prettierignore
+.prettierrc
+.prettierrc.js
+jest.config.js

--- a/biogrid/apps/api/src/app/config/constants.ts
+++ b/biogrid/apps/api/src/app/config/constants.ts
@@ -2,7 +2,7 @@ const { env } = process;
 
 export default {
   environment: env.NODE_ENV,
-  port: Number(env.PORT) || 3333,
+  port: Number(env.PORT) || 8080,
   errorTypes: {
     db: { statusCode: 500, name: 'Internal Server Error', message: 'database error' },
     validation: { statusCode: 400, name: 'Bad Request', message: 'validation error' },

--- a/biogrid/apps/api/src/app/config/constants.ts
+++ b/biogrid/apps/api/src/app/config/constants.ts
@@ -2,7 +2,7 @@ const { env } = process;
 
 export default {
   environment: env.NODE_ENV,
-  port: Number(env.PORT) || 8080,
+  port: Number(env.PORT) || 3333,
   errorTypes: {
     db: { statusCode: 500, name: 'Internal Server Error', message: 'database error' },
     validation: { statusCode: 400, name: 'Bad Request', message: 'validation error' },

--- a/biogrid/apps/biogrid-mvp/src/app/pages/input-page/input-page.tsx
+++ b/biogrid/apps/biogrid-mvp/src/app/pages/input-page/input-page.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import './input-page.css';
 import DatePicker from 'react-datepicker';
 import { Client } from '../../client';
-import { NewBiogridBody } from '../../build';
 import { useHistory } from 'react-router-dom';
 
 function useInput(opts: { type: string }) {
@@ -30,7 +29,7 @@ export const InputPage = () => {
 
   const onSubmit = async (e: React.SyntheticEvent<EventTarget>) => {
     e.preventDefault();
-    const body: NewBiogridBody = {
+    const body = {
       startDate,
       endDate,
       smallBatteryCells: parseInt(smallBatteryCells as string),

--- a/biogrid/apps/biogrid-mvp/src/main.tsx
+++ b/biogrid/apps/biogrid-mvp/src/main.tsx
@@ -3,10 +3,11 @@ import ReactDOM from 'react-dom';
 
 import App from './app/app';
 
-// declare let GlobalFetch;
-declare module 'node-fetch' {
-    const fetch: GlobalFetch['fetch'];
-    export default fetch;
+declare global {
+  interface GlobalFetch {
+    [k: string]: any;
+  }
 }
+window.globalThis = window
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/biogrid/apps/biogrid-mvp/src/main.tsx
+++ b/biogrid/apps/biogrid-mvp/src/main.tsx
@@ -3,4 +3,10 @@ import ReactDOM from 'react-dom';
 
 import App from './app/app';
 
+// declare let GlobalFetch;
+declare module 'node-fetch' {
+    const fetch: GlobalFetch['fetch'];
+    export default fetch;
+}
+
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/biogrid/nx.json
+++ b/biogrid/nx.json
@@ -6,6 +6,9 @@
       "dependencies": "*",
       "devDependencies": "*"
     },
+    "globalFile": [
+      "biogrid-mvp"
+    ],
     "tsconfig.json": "*",
     "tslint.json": "*",
     "nx.json": "*"

--- a/biogrid/package.json
+++ b/biogrid/package.json
@@ -7,8 +7,8 @@
   "license": "MIT",
   "scripts": {
     "nx": "nx",
-    "fullstack:dev": "PORT=3333 && npm run build:tsoa && npm run build-api-client:dev && nx serve-with-api biogrid-mvp",
-    "build-api-client:dev": "(mkdir apps/biogrid-mvp/src/app/build || true) && openapi-generator generate -i ./apps/api/src/app/build/swagger.json --generator-name typescript-fetch -o apps/biogrid-mvp/src/app/build/",
+    "fullstack:dev": "PORT=3333 && npm run build:tsoa && npm run build-api-client && nx serve-with-api biogrid-mvp",
+    "build-api-client": "(mkdir apps/biogrid-mvp/src/app/build || true) && openapi-generator generate -i ./apps/api/src/app/build/swagger.json --generator-name typescript-fetch -o apps/biogrid-mvp/src/app/build/",
     "api:dev": "npm run build:tsoa && nx serve api",
     "frontend:dev": "nx serve biogrid-mvp",
     "build:routes": "(cd apps/api && tsoa routes)",
@@ -91,7 +91,6 @@
     "colors": "^1.2.1",
     "cross-env": "^5.1.4",
     "cypress": "^4.1.0",
-    "dotenv": "6.2.0",
     "eslint": "6.8.0",
     "eslint-config-prettier": "6.0.0",
     "eslint-plugin-cypress": "^2.10.3",

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,10 @@
 steps:
+# Build the container image
 - name: 'gcr.io/cloud-builders/docker'
   args: [ 'build', '-t', 'gcr.io/step-alr-2020/api-image', '.' ]
+# Push the container image to Container Registry
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['push', 'gcr.io/step-alr-2020/api-image']
+# TODO: run and deploy the image from GCP
 images:
 - 'gcr.io/step-alr-2020/api-image'


### PR DESCRIPTION
- Run docker from an image already built with node 12 and java 11
- Install dependency openapi which depends on java
- remove the duplicates from package.json
- define port on 8080